### PR TITLE
Limit set of indicies queried on cloudelastic

### DIFF
--- a/src/Repository/CloudElasticRepository.php
+++ b/src/Repository/CloudElasticRepository.php
@@ -38,7 +38,15 @@ class CloudElasticRepository
      */
     public function makeRequest(): array
     {
-        $uri = $_ENV['ELASTIC_HOST'].'/*,*:*/_search';
+        $indices = implode( ',', [
+            '*_content',
+            '*_general',
+            '*_file',
+            '*:*_content',
+            '*:*_general',
+            '*:*_file',
+        ] );
+        $uri = $_ENV['ELASTIC_HOST'].'/'.$indices.'/_search';
 
         $request = new Request('GET', $uri, [
             'Content-Type' => 'application/json',


### PR DESCRIPTION
Cloudelastic has two ways to target the indices to query. There are the exact index names, such as foowiki_content_12345, and there are aliases pointing to the current live index, such as foowiki_content.

The prior index selection method, taking everything with `*,*:*`, captured not only the live indices but also indices that were not live and not intended to be queried.

Patch adjusts the index selection method such that it will target the known named aliases provided by CirrusSearch.