### PR TITLE
Add preset for Lua

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -46,6 +46,10 @@ $(() => {
                 $('#namespaceIds').val('2,4,8');
                 $('#titlePattern').val('(Gadgets-definition|.*\\.(js|css|json))');
                 break;
+            case 'lua':
+                $('#namespaceIds').val('828');
+                $('#titlePattern').val('');
+                break;
             case 'subject':
                 $('#namespaceIds').val('0,2,4,6,8,10,12,14');
                 $('#titlePattern').val('');

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -111,6 +111,8 @@
                             {{ msg('presets') }}:
                             <a href="#" class="preset-link" data-value="js">JS/CSS/JSON</a>
                             &middot;
+                            <a href="#" class="preset-link" data-value="lua">Lua</a>
+                            &middot;
                             <a href="#" class="preset-link" data-value="subject">{{ msg('subject-pages') }}</a>
                             &middot;
                             <a href="#" class="preset-link" data-value="talk">{{ msg('talk-pages') }}</a>


### PR DESCRIPTION
The Module namespace name is hard to memorize and is probably one of the more common use cases for cross-wiki source search.

(I did not test the change but it's trivial.)