### PR TITLE
Don't reset form when using presets

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -40,8 +40,6 @@ $(() => {
 
     $('.preset-link').on('click', e => {
         e.preventDefault();
-        document.querySelector('form').reset();
-        $('#regexCheckbox').trigger('change');
 
         switch (e.target.dataset.value) {
             case 'js':


### PR DESCRIPTION
A form reset and a checkbox change trigger were added in 2080485c. It's unhelpful to reset the whole form and each case already resets the fields necessary.