### PR TITLE
Avoid duplicate results from cross-cluster search

### DIFF
--- a/src/Repository/CloudElasticRepository.php
+++ b/src/Repository/CloudElasticRepository.php
@@ -39,9 +39,6 @@ class CloudElasticRepository
     public function makeRequest(): array
     {
         $indices = implode( ',', [
-            '*_content',
-            '*_general',
-            '*_file',
             '*:*_content',
             '*:*_general',
             '*:*_file',


### PR DESCRIPTION
In the past when this ran against elasticsearch 7.10 we needed to specify that we wanted to query both the local and remote clusters, but it looks like that is no longer the case with opensearch 1.3. Under opensearch 1.3 it appears to be querying the local indices twice.

Note that this is, in part, because in the wmf deployments all clusters have the exact same cross-cluster configuration, meaning they can access themselves via cross-cluster.

Bug: T391175